### PR TITLE
Import the `Settings` class before using it. Resolves #6

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ namespace Gamajo\PluginSlug;
 use BrightNucleus\Config\ConfigInterface;
 use BrightNucleus\Config\ConfigTrait;
 use BrightNucleus\Exception\RuntimeException;
+use BrightNucleus\Settings\Settings;
 
 /**
  * Main plugin class.


### PR DESCRIPTION
Adds the missing `use` statement for the `Settings` class.
