### PR TITLE
Use the more specific `FailedToProcessConfigException`. Resolves #8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": ">=7.0",
         "composer/installers": "~1.0",
         "brightnucleus/config": "^0.4",
-        "wpupdatephp/wp-update-php": "^1.0"
+        "wpupdatephp/wp-update-php": "^1.0",
+        "brightnucleus/settings": "^0.1.4"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ca93888697e7729dce93138bf21b97ed",
-    "content-hash": "5ecdaf2ce66d8bebf7b65ee48cc0e653",
+    "hash": "9ea22e6bd6a23549563f8369fbfcae3c",
+    "content-hash": "4c65abc4ba8d6c80f4bae73666eda593",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -144,6 +144,84 @@
             "time": "2016-04-05 07:46:33"
         },
         {
+            "name": "brightnucleus/invoker",
+            "version": "v0.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brightnucleus/invoker.git",
+                "reference": "593539ea3f1eb416ee04c7397f62ec8f5b75cf40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brightnucleus/invoker/zipball/593539ea3f1eb416ee04c7397f62ec8f5b75cf40",
+                "reference": "593539ea3f1eb416ee04c7397f62ec8f5b75cf40",
+                "shasum": ""
+            },
+            "require": {
+                "brightnucleus/exceptions": "^0.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4",
+                "squizlabs/php_codesniffer": "~2.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BrightNucleus\\Invoker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Alain Schlesser",
+                    "email": "alain.schlesser@gmail.com"
+                }
+            ],
+            "description": "Function and method invoking traits that match named arguments in the right order.",
+            "time": "2016-02-26 09:45:55"
+        },
+        {
+            "name": "brightnucleus/settings",
+            "version": "v0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brightnucleus/settings.git",
+                "reference": "e5c6bf27bb503660ca1c1849cbbba5d5ff04b659"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brightnucleus/settings/zipball/e5c6bf27bb503660ca1c1849cbbba5d5ff04b659",
+                "reference": "e5c6bf27bb503660ca1c1849cbbba5d5ff04b659",
+                "shasum": ""
+            },
+            "require": {
+                "brightnucleus/config": ">=0.2",
+                "brightnucleus/exceptions": ">=0.2",
+                "brightnucleus/invoker": ">=0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BrightNucleus\\Settings\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alain Schlesser",
+                    "email": "alain.schlesser@gmail.com"
+                }
+            ],
+            "description": "Config-driven WordPress settings.",
+            "time": "2016-05-14 05:37:36"
+        },
+        {
             "name": "composer/installers",
             "version": "v1.0.25",
             "source": {
@@ -245,16 +323,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "77f7252e377e1dc021ba74defe12a19a45bb1212"
+                "reference": "30605874d99af0cde6c41fd39e18546330c38100"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/77f7252e377e1dc021ba74defe12a19a45bb1212",
-                "reference": "77f7252e377e1dc021ba74defe12a19a45bb1212",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/30605874d99af0cde6c41fd39e18546330c38100",
+                "reference": "30605874d99af0cde6c41fd39e18546330c38100",
                 "shasum": ""
             },
             "require": {
@@ -263,7 +341,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -295,7 +373,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2016-05-09 18:14:44"
+            "time": "2016-05-12 15:59:27"
         },
         {
             "name": "wpupdatephp/wp-update-php",
@@ -535,16 +613,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "3.3.1",
+            "version": "3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2431befdd451fac43fbcde94d1a92fb3b8b68f86"
+                "reference": "44cd8e3930e431658d1a5de7d282d5cb37837fd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2431befdd451fac43fbcde94d1a92fb3b8b68f86",
-                "reference": "2431befdd451fac43fbcde94d1a92fb3b8b68f86",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/44cd8e3930e431658d1a5de7d282d5cb37837fd5",
+                "reference": "44cd8e3930e431658d1a5de7d282d5cb37837fd5",
                 "shasum": ""
             },
             "require": {
@@ -594,7 +672,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-04-08 08:14:53"
+            "time": "2016-05-27 16:24:29"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -779,16 +857,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.3.2",
+            "version": "5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2c6da3536035617bae3fe3db37283c9e0eb63ab3"
+                "reference": "00dd95ffb48805503817ced06399017df315fe5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2c6da3536035617bae3fe3db37283c9e0eb63ab3",
-                "reference": "2c6da3536035617bae3fe3db37283c9e0eb63ab3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/00dd95ffb48805503817ced06399017df315fe5c",
+                "reference": "00dd95ffb48805503817ced06399017df315fe5c",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +928,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-04-12 16:20:08"
+            "time": "2016-05-11 13:28:45"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1071,16 +1149,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.6",
+            "version": "1.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "2292b116f43c272ff4328083096114f84ea46a56"
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/2292b116f43c272ff4328083096114f84ea46a56",
-                "reference": "2292b116f43c272ff4328083096114f84ea46a56",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
                 "shasum": ""
             },
             "require": {
@@ -1117,7 +1195,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-04 07:59:13"
+            "time": "2016-05-17 03:18:57"
         },
         {
             "name": "sebastian/exporter",
@@ -1422,16 +1500,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b"
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1bcdf03b068a530ac1962ce671dead356eeba43b",
-                "reference": "1bcdf03b068a530ac1962ce671dead356eeba43b",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
                 "shasum": ""
             },
             "require": {
@@ -1496,20 +1574,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-04-03 22:58:34"
+            "time": "2016-05-30 22:24:32"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.6",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96"
+                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0047c8366744a16de7516622c5b7355336afae96",
-                "reference": "0047c8366744a16de7516622c5b7355336afae96",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
+                "reference": "eca51b7b65eb9be6af88ad7cc91685f1556f5c9a",
                 "shasum": ""
             },
             "require": {
@@ -1518,7 +1596,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -1545,7 +1623,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:55:57"
+            "time": "2016-05-26 21:46:24"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/plugin-slug.php
+++ b/plugin-slug.php
@@ -21,7 +21,7 @@
 
 namespace Gamajo\PluginSlug;
 
-use BrightNucleus\Config\Config;
+use BrightNucleus\Config\ConfigFactory;
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
@@ -41,5 +41,5 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 // Initialize the plugin.
-$config = new Config( include __DIR__ . '/config/defaults.php' );
+$config = ConfigFactory::create( __DIR__ . '/config/defaults.php' );
 Plugin::get_instance( $config->getSubConfig( 'Gamajo\PluginSlug' ) )->run();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ namespace Gamajo\PluginSlug;
 use BrightNucleus\Config\ConfigInterface;
 use BrightNucleus\Config\ConfigTrait;
 use BrightNucleus\Exception\RuntimeException;
+use BrightNucleus\Settings\Settings;
 
 /**
  * Main plugin class.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,7 @@ namespace Gamajo\PluginSlug;
 
 use BrightNucleus\Config\ConfigInterface;
 use BrightNucleus\Config\ConfigTrait;
-use BrightNucleus\Exception\RuntimeException;
+use BrightNucleus\Config\Exception\FailedToProcessConfigException;
 use BrightNucleus\Settings\Settings;
 
 /**
@@ -44,7 +44,7 @@ class Plugin {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @throws RuntimeException If the Config could not be parsed correctly.
+	 * @throws FailedToProcessConfigException If the Config could not be parsed correctly.
 	 *
 	 * @param ConfigInterface $config Config to parametrize the object.
 	 */
@@ -57,7 +57,7 @@ class Plugin {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @throws RuntimeException If the Config could not be parsed correctly.
+	 * @throws FailedToProcessConfigException If the Config could not be parsed correctly.
 	 *
 	 * @param ConfigInterface $config Optional. Config to parametrize the
 	 *                                object.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,7 @@ namespace Gamajo\PluginSlug;
 
 use BrightNucleus\Config\ConfigInterface;
 use BrightNucleus\Config\ConfigTrait;
-use BrightNucleus\Exception\RuntimeException;
+use BrightNucleus\Config\Exception\FailedToProcessConfigException;
 
 /**
  * Main plugin class.
@@ -43,7 +43,7 @@ class Plugin {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @throws RuntimeException If the Config could not be parsed correctly.
+	 * @throws FailedToProcessConfigException If the Config could not be parsed correctly.
 	 *
 	 * @param ConfigInterface $config Config to parametrize the object.
 	 */
@@ -56,7 +56,7 @@ class Plugin {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @throws RuntimeException If the Config could not be parsed correctly.
+	 * @throws FailedToProcessConfigException If the Config could not be parsed correctly.
 	 *
 	 * @param ConfigInterface $config Optional. Config to parametrize the
 	 *                                object.


### PR DESCRIPTION
Contrary to general parent `BrightNucleus\Exceptions\RuntimeException`, the more specific `BrightNucleus\Config\Exception\FailedToProcessConfigException` is specific to the `brightnucleus/config` package, and can be caught as both a `RuntimeException` as well as a `ConfigException`.
