### PR TITLE
CI: Add SVN install for ubuntu-latest

### DIFF
--- a/.github/workflows/plugin-assets-readme-update.yml
+++ b/.github/workflows/plugin-assets-readme-update.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Install SVN (Subversion)
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
       - name: WordPress.org plugin asset/readme update
         uses: 10up/action-wordpress-plugin-asset-update@stable
         env:

--- a/.github/workflows/plugin-push-to-wordpress-org.yml
+++ b/.github/workflows/plugin-push-to-wordpress-org.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install SVN (Subversion)
+        run: |
+          sudo apt-get update
+          sudo apt-get install subversion
       - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:


### PR DESCRIPTION
When ubunutu-latest switches to be an alias for ubuntu-24.04, it will no longer have SVN available, so we need to manually install it before trying to use it in the subsequent action.

Refs:
- https://github.com/actions/runner-images/issues/10636
- https://github.com/10up/action-wordpress-plugin-deploy/pull/155
