### PR TITLE
Fix asset update workflow after default branch rename

### DIFF
--- a/.github/workflows/plugin-assets-readme-update.yml
+++ b/.github/workflows/plugin-assets-readme-update.yml
@@ -9,7 +9,7 @@ name: Plugin asset/readme update
 on:
   push:
     branches:
-      - master
+      - main
 
 # Serialise WordPress.org SVN updates to avoid overlapping commits to the same
 # repository. Do not cancel an in-progress run, since it may already be pushing.
@@ -20,7 +20,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  master:
+  assets:
     name: Update plugin and assets
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

When the default branch was renamed from master to main, the plugin asset/readme update workflow was left triggering on pushes to master, a branch that no longer receives any. The workflow has been silently dead since the rename, so readme and asset changes would never have been deployed to WordPress.org.

This points the push trigger at main, and renames the job id from `master` to `assets` so the workflow carries no lingering reference to the old branch name. The job's display name is unchanged, and nothing else in the workflow is touched.