### PR TITLE
Add PHPStan static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,13 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"infection/infection": "^0.33",
 		"phpcompatibility/phpcompatibility-wp": "^2",
+		"phpstan/extension-installer": "^1.4",
+		"phpstan/phpstan": "^2.2",
 		"phpunit/phpunit": "^9",
 		"rector/rector": "^2.4",
 		"roave/security-advisories": "dev-master",
 		"squizlabs/php_codesniffer": "^3",
+		"szepeviktor/phpstan-wordpress": "^2.0",
 		"wp-coding-standards/wpcs": "^3",
 		"yoast/phpunit-polyfills": "^4"
 	},
@@ -39,7 +42,8 @@
 		"allow-plugins": {
 			"composer/installers": true,
 			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"infection/extension-installer": true
+			"infection/extension-installer": true,
+			"phpstan/extension-installer": true
 		}
 	},
 	"autoload": {
@@ -63,6 +67,7 @@
 		],
 		"cbf": "@php vendor/bin/phpcbf",
 		"cs": "@php vendor/bin/phpcs",
+		"phpstan": "phpstan analyse",
 		"test": [
 			"@lint",
 			"@unit",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,13 @@
 # views/ and config/ are deliberately not analysed: those files are pulled in
 # via include/require and rely on variables injected into their scope at
 # runtime (template data, plugin constants), which PHPStan cannot see.
+#
+# Level 8 is the ceiling for this codebase: level 9 adds checkExplicitMixed,
+# which fights the untyped boundary of config-driven WordPress code — the
+# BrightNucleus Config accessors return mixed by design. Revisit if the
+# config ever gains a typed accessor layer.
 parameters:
-	level: max
+	level: 8
 	paths:
 		- plugin-slug.php
 		- src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,13 @@
+# PHPStan configuration.
+#
+# The WordPress stubs and rules are loaded automatically from
+# szepeviktor/phpstan-wordpress via phpstan/extension-installer.
+#
+# views/ and config/ are deliberately not analysed: those files are pulled in
+# via include/require and rely on variables injected into their scope at
+# runtime (template data, plugin constants), which PHPStan cannot see.
+parameters:
+	level: max
+	paths:
+		- plugin-slug.php
+		- src


### PR DESCRIPTION
The boilerplate has lacked static analysis since an earlier Psalm setup was removed (a stray `psalm.xml` export-ignore is all that remains). This adds PHPStan with the WordPress extension, auto-registered through `phpstan/extension-installer`, plus a `composer phpstan` script. Analysis runs at level 8 with no baseline and no ignores. Level 9 would add `checkExplicitMixed`, which rejects the untyped boundary of config-driven code — the BrightNucleus Config accessors return `mixed` by design — so 8 is the honest ceiling, with the reasoning recorded in the config. The `views/` and `config/` templates are excluded as they rely on variables injected into their scope at runtime. The change is cleanly declinable. This PR is stacked on #40 (both touch adjacent `composer.json` lines, so the conflict is resolved here in a merge commit); it retargets to main automatically once #40 merges.

