### PR TITLE
Tidy release packaging and repository hygiene

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,36 @@
+# Exclude these files when deploying to WordPress.org SVN using the
+# https://github.com/10up/action-wordpress-plugin-deploy GitHub Action,
+# which prefers this file over .gitattributes export-ignore entries.
+
+# Directories
+/.git
+/.github
+/.wordpress-org
+/bin
+/node_modules
+/tests
+
+# Files
+/.distignore
+/.editorconfig
+/.gitattributes
+/.gitignore
+/.phpcs.xml.dist
+/.wp-env.json
+/.wp-env.override.json
+/_config.yml
+/CODE_OF_CONDUCT.md
+/composer.json
+/composer.lock
+/infection.json.dist
+/package.json
+/package-lock.json
+/phpunit.xml.dist
+/rector.php
+
+# Caches, logs, and OS files
+/.phpunit.cache
+/logs
+.DS_Store
+.phpcs.cache
+*.log

--- a/.distignore
+++ b/.distignore
@@ -25,6 +25,7 @@
 /infection.json.dist
 /package.json
 /package-lock.json
+/phpstan.neon.dist
 /phpunit.xml.dist
 /rector.php
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.yml]
+[*.{yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -35,5 +35,6 @@
 /composer.lock       export-ignore
 /infection.json.dist export-ignore
 /package.json        export-ignore
+/phpstan.neon.dist   export-ignore
 /phpunit.xml.dist    export-ignore
 /rector.php          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# Normalise line endings to LF in the repository.
+* text=auto
+*.php text
+*.md  text
+*.yml text
+
 # Exclude these files from release archives.
 
 # This will also make them unavailable when using Composer with `--prefer-dist`.
@@ -16,15 +22,18 @@
 /tests               export-ignore
 
 # Files
-/.editorconfig        export-ignore
+/.distignore         export-ignore
+/.editorconfig       export-ignore
 /.gitattributes      export-ignore
 /.gitignore          export-ignore
 /.phpcs.xml.dist     export-ignore
-/_config.yml          export-ignore
+/.wp-env.json        export-ignore
+/_config.yml         export-ignore
 /CHANGELOG.md        export-ignore
 /CODE_OF_CONDUCT.md  export-ignore
 /composer.json       export-ignore
 /composer.lock       export-ignore
 /infection.json.dist export-ignore
+/package.json        export-ignore
 /phpunit.xml.dist    export-ignore
-/psalm.xml           export-ignore
+/rector.php          export-ignore

--- a/.github/workflows/plugin-push-to-wordpress-org.yml
+++ b/.github/workflows/plugin-push-to-wordpress-org.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Set up PHP

--- a/.github/workflows/plugin-push-to-wordpress-org.yml
+++ b/.github/workflows/plugin-push-to-wordpress-org.yml
@@ -31,6 +31,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+      - name: Install production dependencies
+        run: composer install --no-dev --optimize-autoloader
       - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:

--- a/.github/workflows/plugin-push-to-wordpress-org.yml
+++ b/.github/workflows/plugin-push-to-wordpress-org.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
-          SLUG: my-super-cool-plugin # Change this
+          SLUG: plugin-slug # Change this
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         continue-on-error: true # Remove for real plugin

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /.phpcs.xml
 /phpcs.xml
 /phpunit.xml
+/.wp-env.override.json
+.phpcs.cache
+package-lock.json
+*.log
+npm-debug.log*
+.DS_Store

--- a/.wordpress-org/icon.svg
+++ b/.wordpress-org/icon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Plugin icon placeholder">
+	<rect width="128" height="128" rx="24" fill="#5f7470"/>
+	<text x="64" y="89" fill="#f2f4f3" font-family="Georgia, 'Times New Roman', serif" font-size="72" font-weight="bold" text-anchor="middle">P</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
-	"name": "PLUGIN-SLUG",
+	"name": "plugin-slug",
 	"version": "0.1.0",
 	"description": "Short description of the plugin.",
 	"license": "GPL-2.0-or-later",
 	"private": true,
 	"repository": "GaryJones/plugin-boilerplate",
+	"engines": {
+		"node": ">=24"
+	},
 	"scripts": {
-		"bump:patch": "bump patch --commit 'Version %s.' package.json package-lock.json plugin-slug.php README.md",
-		"bump:minor": "bump minor --commit 'Version %s.' package.json package-lock.json plugin-slug.php README.md",
-		"bump:major": "bump major --commit 'Version %s.' package.json package-lock.json plugin-slug.php README.md"
+		"bump:patch": "bump patch --commit 'Version %s.' package.json plugin-slug.php README.md",
+		"bump:minor": "bump minor --commit 'Version %s.' package.json plugin-slug.php README.md",
+		"bump:major": "bump major --commit 'Version %s.' package.json plugin-slug.php README.md"
+	},
+	"devDependencies": {
+		"version-bump-prompt": "^6.1.0"
 	}
 }


### PR DESCRIPTION
## Summary

The headline fix is in the WordPress.org deploy workflow: the 10up action shipped the raw checkout, which has no `vendor/` directory, so a released plugin would be missing its Composer autoloader and production dependencies entirely and fatal on load. The workflow now installs no-dev optimised dependencies before deploying, using a plain `composer install` step rather than ramsey/composer-install since no lock file is committed. The deploy `SLUG` also now uses the `plugin-slug` placeholder for consistency with the rest of the boilerplate, and the checkout action moves to v6.0.3.

A new `.distignore` accompanies this, since the 10up action prefers it over `.gitattributes` export-ignore entries and it is the only mechanism that can exclude untracked artefacts like `node_modules` from the deployed package. The `.gitattributes` itself gains line ending normalisation, loses the stale `psalm.xml` entry, and now export-ignores `rector.php`, `.wp-env.json`, and `package.json`. The `.gitignore` picks up wp-env overrides, the PHPCS cache, npm lock and log files, and macOS metadata, and the EditorConfig YAML rule now covers `.yaml` as well as `.yml`.

Two correctness fixes round things off: `.wordpress-org/icon.svg` was zero bytes and is now a small valid placeholder, and `package.json` had an invalid uppercase name, called an undeclared `bump` CLI (now declared as version-bump-prompt), and listed a non-existent `package-lock.json` in its bump scripts. It also gains an `engines` field for the current Node LTS.

One deliberate non-change: `_config.yml` looked like a Jekyll leftover, but GitHub Pages is enabled for this repository (legacy build from the main branch root), so the file stays.