### PR TITLE
Refresh PHPCS and Rector configs for PHP 8.4 and WordPress 6.9

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -29,7 +29,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="8.1-"/>
+	<config name="testVersion" value="8.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
@@ -38,7 +38,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="6.6"/>
+	<config name="minimum_supported_wp_version" value="6.9"/>
 
 	<rule ref="WordPress.Files.FileName">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -2,13 +2,13 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PluginSlug" xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Custom ruleset for PluginSlug plugin.</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+	<!-- For help in understanding this file: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset -->
+	<!-- For help in using PHPCS: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Usage -->
 
 	<!-- What to scan -->
 	<file>.</file>
 	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+		https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
 	<exclude-pattern>./node_modules/</exclude-pattern>
 	<exclude-pattern>./vendor/</exclude-pattern>
 
@@ -19,6 +19,8 @@
 	<arg name="colors"/>
 	<!-- Strip the file paths down to the relevant bit -->
 	<arg name="basepath" value="."/>
+	<!-- Cache results between runs for faster repeat scans -->
+	<arg name="cache" value=".phpcs.cache"/>
 	<!-- Enables parallel processing when available for faster results. -->
 	<arg name="parallel" value="20"/>
 	<!-- Limit to PHP files -->
@@ -32,12 +34,17 @@
 	<config name="testVersion" value="8.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<!-- WordPress-Extra includes WordPress-Core -->
-	<rule ref="WordPress-Extra"/>
-	<rule ref="WordPress-Docs"/>
+		https://github.com/WordPress/WordPress-Coding-Standards -->
+	<!-- The WordPress standard contains WordPress-Core, WordPress-Docs, and WordPress-Extra. -->
+	<rule ref="WordPress">
+		<!-- WordPress insists on long array syntax; this plugin prefers short array syntax. -->
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+		<!-- Rector's dead code set removes redundant @var tags; native property types
+			document these instead, so don't demand the tags be restored. -->
+		<exclude name="Squiz.Commenting.VariableComment"/>
+	</rule>
 	<!-- For help in understanding these custom sniff properties:
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+		https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
 	<config name="minimum_supported_wp_version" value="6.9"/>
 
 	<rule ref="WordPress.Files.FileName">
@@ -68,12 +75,6 @@
 		<properties>
 			<property name="blank_line_check" value="true"/>
 		</properties>
-	</rule>
-
-	<!-- WordPress insists on long array syntax, so let's ignore that. -->
-	<rule ref="WordPress">
-		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
-		<exclude name="Squiz.Commenting.VariableComment"/>
 	</rule>
 
 	<!-- Rules: WordPress VIP Go, for WordPress VIP - see

--- a/rector.php
+++ b/rector.php
@@ -4,15 +4,13 @@
  *
  * @package      Gamajo\PluginSlug
  * @author       Gary Jones
- * @copyright    2024 Gary Jones
+ * @copyright    2024-2026 Gary Jones
  * @license      GPL-2.0-or-later
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 use Rector\Config\RectorConfig;
-use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
-use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 
 return RectorConfig::configure()
 	->withPaths(
@@ -23,15 +21,5 @@ return RectorConfig::configure()
 			__DIR__ . '/plugin-slug.php',
 		]
 	)
-	->withPhpSets( php82: true )
-	// Changes from later PHP Sets that are backwards compatible.
-	->withRules(
-		[
-			// 8.3.
-			AddOverrideAttributeToOverriddenMethodsRector::class,
-
-			// 8.4.
-			ExplicitNullableParamTypeRector::class,
-		]
-	)
+	->withPhpSets( php84: true )
 	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true, typeDeclarations: true );


### PR DESCRIPTION
## Summary

The code standards tooling lagged the project's actual support floors: composer requires PHP ^8.4 and the plugin supports the latest two WordPress versions, yet PHPCS still sniffed against PHP 8.1 and WordPress 6.6, and Rector applied the PHP 8.2 set with two cherry-picked 8.3/8.4 rules bolted on.

The PHPCS ruleset now declares `testVersion` 8.4- and `minimum_supported_wp_version` 6.9. Its redundant layering is also collapsed: WordPress-Extra and WordPress-Docs were included separately, then the full WordPress standard was referenced again lower down just to attach two excludes. Since WordPress already contains Core, Docs, and Extra, a single reference with the excludes attached gives one coherent layer; the registered sniff list (verified with `phpcs -e`) is byte-identical before and after, and the repo still passes cleanly. Along the way the ruleset gains a results cache for faster repeat scans, and its documentation links now point at the PHPCSStandards and WordPress orgs, where those projects moved.

Rector now uses `withPhpSets( php84: true )`, which already contains the two previously cherry-picked rules, so they and their imports are gone. The config also adopts the project's `declare( strict_types = 1 );` spacing and a 2024-2026 copyright range.

A Rector dry run with the new config suggests the PHP 8.4 `new Testee()->method()` form (dropping the wrapping parentheses) in the two test files; those files are deliberately left untouched here. The new `.phpcs.cache` file is not yet gitignored, which also sits outside this change.