### PR TITLE
Drop dev dependencies that arrive transitively

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
 	"require-dev": {
 		"automattic/vipwpcs": "^3",
 		"brain/monkey": "^2",
-		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"ergebnis/composer-normalize": "^2.52",
 		"infection/infection": "^0.33",
 		"mockery/mockery": "^1.6",
@@ -37,8 +36,6 @@
 		"phpstan/phpstan": "^2.2",
 		"phpunit/phpunit": "^9.6",
 		"rector/rector": "^2.4",
-		"roave/security-advisories": "dev-latest",
-		"squizlabs/php_codesniffer": "^3",
 		"szepeviktor/phpstan-wordpress": "^2.0",
 		"wp-coding-standards/wpcs": "^3",
 		"yoast/phpunit-polyfills": "^4"


### PR DESCRIPTION
Three development dependencies were declared directly while other packages already pull them in, so the boilerplate was telling consumers to require things they get for free.

`roave/security-advisories` blocked installing known-vulnerable versions at composer time. Composer's own `composer audit`, which the CI lint job runs, now covers that ground, so the metapackage is redundant. `dealerdirect/phpcodesniffer-composer-installer` is a dependency of the sniff tooling itself (via `phpcsstandards/phpcsutils`); only its `allow-plugins` entry needs to stay, since Composer must still be told the plugin may run. `squizlabs/php_codesniffer` is required by WPCS, VIPCS and PHPCompatibility, which between them resolve the most compatible version — here, 3.13.5 — without our help.

I checked the rest of the dev block while I was at it. `brain/monkey` and `yoast/phpunit-polyfills` are both root-only: nothing else pulls them, and the test suite needs them (Brain Monkey is imported in the base test case, the polyfills are required by the WordPress core integration framework). `mockery` *is* pulled in by Brain Monkey, but the base test case imports `MockeryPHPUnitIntegration` directly, so it stays declared on the principle that you require what you import. That is the line: libraries the code imports are declared, tools whose version is dictated by a parent package are not.

Verified with the full suite — coding standards, unit tests, PHPStan, lint, normalisation, Infection at 100% MSI, and a clean `composer audit`.